### PR TITLE
Move PenaltyFunctions and LearningStrategies from build.jl to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,5 @@ LearnBase
 LossFunctions
 MLDataUtils
 CatViews
+PenaltyFunctions
+LearningStrategies

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,6 @@
 
-for pkg in ("Transformations", "ObjectiveFunctions", "StochasticOptimization", "MLMetrics", "PenaltyFunctions", "LearningStrategies")
-    org = pkg == "CatViews" ? "ahwillia" : "JuliaML"
+for pkg in ("Transformations", "ObjectiveFunctions", "StochasticOptimization", "MLMetrics")
+    org = "JuliaML"
 	try
 		avail = Pkg.available(pkg)
 		if !isempty(avail)


### PR DESCRIPTION
(since they've been registered). 

I'm not familiar with the JuliaML ecosystem yet, but I believe this is the correct thing to do, given that `Pkg.build("Learn")` currently gives:

```
WARNING: PenaltyFunctions is registered in METADATA... it shouldn't be in /home/rdeits/.julia/v0.6/Learn/deps/build.jl
WARNING: LearningStrategies is registered in METADATA... it shouldn't be in /home/rdeits/.julia/v0.6/Learn/deps/build.jl
```